### PR TITLE
delete and recreate user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ ARG USERNAME=coder
 
 # the container has an 'ubuntu' user.
 # Change the username to something else.
-RUN usermod -l $USERNAME -d /home/$USERNAME -m ubuntu
+RUN userdel -r ubuntu
+RUN useradd -m $USERNAME
+RUN usermod --add-subuids 100000-165535 --add-subgids 100000-165535 $USERNAME
 
 
 RUN apt-get update


### PR DESCRIPTION
Create a new user rather than renaming the default ubuntu user.

The problem with just renaming the user is that /etc/subuid and /etc/subgid do not update.
Without it, podman can't run containers as the new user.
